### PR TITLE
feat: support get order by order id or client order id or tx hash

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -15,7 +15,7 @@ import SectionSubmitSpotOrderLimit from './components/SectionSubmitSpotOrderLimi
 import SectionSubmitSpotOrderSwapV2 from './components/SectionSubmitSpotOrderSwapV2';
 import SectionCancelSpotOrder from './components/SectionCancelSpotOrder';
 import SectionGetOrders from './components/SectionGetOrders';
-import SectionGetOrderById from './components/SectionGetOrderById';
+import SectionGetOrder from './components/SectionGetOrder.tsx';
 import SectionGetOrderTrades from './components/SectionGetOrderTrades';
 import SectionGetWalletBalances from './components/SectionGetWalletBalances';
 import SectionGetNonce from './components/SectionGetNonce';
@@ -59,7 +59,7 @@ const App: FC = () => {
       <SectionSubmitSpotOrderSwapV2 client={client} />
       <SectionCancelSpotOrder client={client} />
       <SectionGetOrders client={client} />
-      <SectionGetOrderById client={client} />
+      <SectionGetOrder client={client} />
       <SectionGetOrderTrades client={client} />
       <SectionGetWalletBalances client={client} />
       <SectionGetNonce client={client} />

--- a/example/components/SectionGetOrder.tsx
+++ b/example/components/SectionGetOrder.tsx
@@ -8,10 +8,12 @@ import { object, string } from 'yup';
 import FormField from './FormField';
 
 const schema = object({
-  orderId: string().required('Order ID is required')
+  orderId: string(),
+  clientOrderId: string(),
+  txHash: string()
 });
 
-export default function SectionGetOrderById({ client }: { client: HibitClient }) {
+export default function SectionGetOrder({ client }: { client: HibitClient }) {
   const [loading, setLoading] = useState(false);
   const [result, setResult] = useState<OrderInfo | null>(null);
   const [error, setError] = useState<string>('');
@@ -29,7 +31,7 @@ export default function SectionGetOrderById({ client }: { client: HibitClient })
     setResult(null);
     setError('');
     try {
-      setResult(await client.getOrder(input.orderId));
+      setResult(await client.getOrder(input));
     } catch (e: any) {
       setError(e.message ?? JSON.stringify(e));
     } finally {
@@ -39,11 +41,17 @@ export default function SectionGetOrderById({ client }: { client: HibitClient })
 
   return (
     <Section
-      title="GetOrderById"
+      title="GetOrder"
       form={
         <div className="flex flex-col gap-2">
-          <FormField label="Order ID" error={errors.orderId} required>
+          <FormField label="Order ID" error={errors.orderId}>
             <input type="text" className="input" {...register('orderId')} />
+          </FormField>
+          <FormField label="Client Order ID" error={errors.clientOrderId}>
+            <input type="text" className="input" {...register('clientOrderId')} />
+          </FormField>
+          <FormField label="Tx Hash" error={errors.txHash}>
+            <input type="text" className="input" {...register('txHash')} />
           </FormField>
           <button className="btn" onClick={submit} disabled={loading}>
             {loading ? 'Loading...' : 'Submit'}

--- a/example/components/SectionGetOrder.tsx
+++ b/example/components/SectionGetOrder.tsx
@@ -11,7 +11,14 @@ const schema = object({
   orderId: string(),
   clientOrderId: string(),
   txHash: string()
-});
+}).test(
+  'exactly-one-identifier',
+  'Exactly one of Order ID, Client Order ID, or Tx Hash must be provided',
+  function (value) {
+    const providedCount = [!!value.orderId, !!value.clientOrderId, !!value.txHash].filter(Boolean).length;
+    return providedCount === 1;
+  }
+);
 
 export default function SectionGetOrder({ client }: { client: HibitClient }) {
   const [loading, setLoading] = useState(false);

--- a/openapiv1.json
+++ b/openapiv1.json
@@ -6,10 +6,10 @@
   },
   "servers": [
     {
-      "url": "https://testnetopenapi.hibit.io"
+      "url": "https://testnetopenapi.hibit.app"
     },
     {
-      "url": "https://openapi.hibit.io"
+      "url": "https://openapi.hibit.app"
     }
   ],
   "paths": {
@@ -2339,7 +2339,7 @@
     "/v1/order": {
       "get": {
         "tags": ["Orders"],
-        "summary": "get order by the order id",
+        "summary": "get order detail",
         "parameters": [
           {
             "name": "OrderId",
@@ -2348,6 +2348,22 @@
             "schema": {
               "type": "string",
               "format": "string"
+            }
+          },
+          {
+            "name": "ClientOrderId",
+            "in": "query",
+            "description": "Client order id. Format: \"${HIN}_${nonce}\".\r\nExample: \"10001_123\"",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "TxHash",
+            "in": "query",
+            "description": "tx hash",
+            "schema": {
+              "type": "string"
             }
           }
         ],
@@ -3951,6 +3967,7 @@
       "Ex3.Models.OrderCategory": {
         "enum": [0, 1],
         "type": "integer",
+        "description": "Order category",
         "format": "int32",
         "x-enumNames": ["SpotLimitOrder", "SpotSwapOrder"],
         "x-enum-varnames": ["SpotLimitOrder", "SpotSwapOrder"],

--- a/src/hibit-client.ts
+++ b/src/hibit-client.ts
@@ -24,7 +24,8 @@ import {
   SubmitSpotOrderInput,
   GetWalletBalancesInput,
   DecimalOptions,
-  HibitNetwork
+  HibitNetwork,
+  GetOrderInput
 } from './types';
 import {
   getV1Assets,
@@ -68,7 +69,7 @@ import {
   mapGetOrderTradesInput,
   mapOrderInfo,
   mapOrderTradeRecord,
-  mapGetOrderByOrderIdInput
+  mapGetOrderInput
 } from './types/order';
 import { TransactionManager } from './tx-manager';
 import { mapTransactionToApiRequest } from './types/tx';
@@ -202,10 +203,10 @@ export interface IHibitClient {
   /**
    * Get order by the order id.
    *
-   * @param {string} orderId - The order id to get the information for.
+   * @param {GetOrderInput} input - The input parameters for getting the order.
    * @returns {Promise<OrderInfo>} A promise that resolves to the order information.
    */
-  getOrder(orderId: string): Promise<OrderInfo>;
+  getOrder(input: GetOrderInput): Promise<OrderInfo>;
 
   /**
    * Get the list of trades for an order.
@@ -380,9 +381,9 @@ export class HibitClient implements IHibitClient {
     };
   }
 
-  async getOrder(orderId: string): Promise<OrderInfo> {
+  async getOrder(input: GetOrderInput): Promise<OrderInfo> {
     const apiName = 'getOrder';
-    const response = await getV1Order(mapGetOrderByOrderIdInput(orderId));
+    const response = await getV1Order(mapGetOrderInput(input));
 
     this.ensureSuccess(apiName, response.data);
 

--- a/src/hibit-client.ts
+++ b/src/hibit-client.ts
@@ -69,7 +69,8 @@ import {
   mapGetOrderTradesInput,
   mapOrderInfo,
   mapOrderTradeRecord,
-  mapGetOrderInput
+  mapGetOrderInput,
+  validateGetOrderInput
 } from './types/order';
 import { TransactionManager } from './tx-manager';
 import { mapTransactionToApiRequest } from './types/tx';
@@ -383,6 +384,15 @@ export class HibitClient implements IHibitClient {
 
   async getOrder(input: GetOrderInput): Promise<OrderInfo> {
     const apiName = 'getOrder';
+
+    if (!validateGetOrderInput(input)) {
+      HibitClientError.throwBadRequestError(
+        apiName,
+        400,
+        'Must have exactly one of the following properties set: `OrderId`, `ClientOrderId`, or `TxHash`'
+      );
+    }
+
     const response = await getV1Order(mapGetOrderInput(input));
 
     this.ensureSuccess(apiName, response.data);

--- a/src/openapi/client.gen.ts
+++ b/src/openapi/client.gen.ts
@@ -20,4 +20,8 @@ export type CreateClientConfig<T extends DefaultClientOptions = ClientOptions> =
   override?: Config<DefaultClientOptions & T>
 ) => Config<Required<DefaultClientOptions> & T>;
 
-export const client = createClient(createConfig<ClientOptions>());
+export const client = createClient(
+  createConfig<ClientOptions>({
+    baseUrl: 'https://testnetopenapi.hibit.app'
+  })
+);

--- a/src/openapi/sdk.gen.ts
+++ b/src/openapi/sdk.gen.ts
@@ -224,7 +224,7 @@ export const getV1Orders = <ThrowOnError extends boolean = false>(options?: Opti
 };
 
 /**
- * get order by the order id
+ * get order detail
  */
 export const getV1Order = <ThrowOnError extends boolean = false>(options?: Options<GetV1OrderData, ThrowOnError>) => {
   return (options?.client ?? _heyApiClient).get<GetV1OrderResponse, GetV1OrderError, ThrowOnError>({

--- a/src/openapi/types.gen.ts
+++ b/src/openapi/types.gen.ts
@@ -460,6 +460,9 @@ export type Ex3ExchangeOpenApiAppServicesWalletOrderTradeListItem = {
 
 export type Ex3ModelsKLineTickSpace = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
 
+/**
+ * Order category
+ */
 export type Ex3ModelsOrderCategory = 0 | 1;
 
 /**
@@ -1340,6 +1343,15 @@ export type GetV1OrderData = {
      * order id
      */
     OrderId?: string;
+    /**
+     * Client order id. Format: "${HIN}_${nonce}".
+     * Example: "10001_123"
+     */
+    ClientOrderId?: string;
+    /**
+     * tx hash
+     */
+    TxHash?: string;
   };
   url: '/v1/order';
 };
@@ -1577,5 +1589,5 @@ export type GetV1WalletBalancesResponses = {
 export type GetV1WalletBalancesResponse = GetV1WalletBalancesResponses[keyof GetV1WalletBalancesResponses];
 
 export type ClientOptions = {
-  baseUrl: `${string}://openapiv1.json` | (string & {});
+  baseUrl: 'https://testnetopenapi.hibit.app' | 'https://openapi.hibit.app' | (string & {});
 };

--- a/src/types/order/index.ts
+++ b/src/types/order/index.ts
@@ -64,6 +64,29 @@ export type GetOrdersInput = {
   orderBy?: string;
 };
 
+/**
+ * Input type for retrieving a specific order.
+ * Must have exactly one of the following properties set: `OrderId`, `ClientOrderId`, or `TxHash`.
+ */
+export type GetOrderInput = {
+  /**
+   * The unique identifier of the order.
+   * Must be set if `clientOrderId` and `txHash` are not provided.
+   */
+  orderId?: string;
+  /**
+   * The client order identifier. Format: "${HIN}_${nonce}".
+   * Example: "10001_123".
+   * Must be set if `orderId` and `txHash` are not provided.
+   */
+  clientOrderId?: string;
+  /**
+   * The transaction hash associated with the order.
+   * Must be set if `orderId` and `clientOrderId` are not provided.
+   */
+  txHash?: string;
+};
+
 export type OrderInfo = {
   /**
    * order id
@@ -313,10 +336,12 @@ export function mapGetOrdersInput(data: GetOrdersInput): Options<GetV1OrdersData
   };
 }
 
-export function mapGetOrderByOrderIdInput(orderId: string): Options<GetV1OrderData, boolean> {
+export function mapGetOrderInput(input: GetOrderInput): Options<GetV1OrderData, boolean> {
   return {
     query: {
-      OrderId: orderId
+      OrderId: input.orderId,
+      ClientOrderId: input.clientOrderId,
+      TxHash: input.txHash
     }
   };
 }

--- a/src/types/order/index.ts
+++ b/src/types/order/index.ts
@@ -87,6 +87,19 @@ export type GetOrderInput = {
   txHash?: string;
 };
 
+/**
+ * Validates that exactly one identifier is provided in the GetOrderInput
+ */
+export function validateGetOrderInput(input: GetOrderInput): boolean {
+  const providedIdentifiers = [
+    input.orderId !== undefined,
+    input.clientOrderId !== undefined,
+    input.txHash !== undefined
+  ].filter(Boolean).length;
+  
+  return providedIdentifiers === 1;
+}
+
 export type OrderInfo = {
   /**
    * order id

--- a/src/types/order/index.ts
+++ b/src/types/order/index.ts
@@ -96,7 +96,7 @@ export function validateGetOrderInput(input: GetOrderInput): boolean {
     input.clientOrderId !== undefined,
     input.txHash !== undefined
   ].filter(Boolean).length;
-  
+
   return providedIdentifiers === 1;
 }
 

--- a/tests/hibit-client.test.ts
+++ b/tests/hibit-client.test.ts
@@ -141,7 +141,16 @@ describe('Hibit Client Test', () => {
       expect(orders.items).toBeInstanceOf(Array);
     });
 
-    // get order
+    it('get order with invalid input should throw error', async () => {
+      // empty
+      await expect(hibitClient.getOrder({})).rejects.toThrow();
+
+      // more than one parameter
+      await expect(
+        hibitClient.getOrder({ orderId: '12000027100000000000000000000003', clientOrderId: 'clientOrderId' })
+      ).rejects.toThrow();
+    });
+
     it('get order', async () => {
       const order = await hibitClient.getOrder({ orderId: '12000027100000000000000000000003' });
       expect(order).toBeInstanceOf(Object);

--- a/tests/hibit-client.test.ts
+++ b/tests/hibit-client.test.ts
@@ -141,9 +141,9 @@ describe('Hibit Client Test', () => {
       expect(orders.items).toBeInstanceOf(Array);
     });
 
-    // get order by id
-    it('should get order by id', async () => {
-      const order = await hibitClient.getOrder('12000027100000000000000000000003');
+    // get order
+    it('get order', async () => {
+      const order = await hibitClient.getOrder({ orderId: '12000027100000000000000000000003' });
       expect(order).toBeInstanceOf(Object);
     });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced order retrieval now supports multiple identifiers, allowing users to input an Order ID, Client Order ID, or Transaction Hash for flexible order searches.

- **API Enhancements**
  - Updated order details endpoint with clearer descriptions and additional query options, alongside refined connectivity settings.

- **Documentation**
  - API documentation has been revised to reflect the new order retrieval options and updated endpoint details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->